### PR TITLE
Update function to calculate breadth first traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sum
 
     TypeError                                 Traceback (most recent call last)
 
-    <ipython-input-5-ac8531805475> in <module>()
+    <ipython-input-5-f1a29f127e30> in <module>()
           2 sum = 0
           3 for x in L:
     ----> 4     sum += x
@@ -206,7 +206,7 @@ def mysum(L, tot=0):
             #Notice we're digging in a layer here by iterating 
             #through i which we know is a nested data structure from our conditional
     if deeper_data != []:
-        return tot + mysum(deeper_data, tot=tot)
+        return mysum(deeper_data, tot=tot)
         #If we have deeper_data we got to iterate!
     else:
         return tot
@@ -224,7 +224,7 @@ mysum(L)
 
 
 
-    81
+    45
 
 
 

--- a/index.ipynb
+++ b/index.ipynb
@@ -208,7 +208,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-5-ac8531805475>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0msum\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mx\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mL\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0msum\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0msum\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-5-f1a29f127e30>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0msum\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mx\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mL\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0msum\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0msum\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mTypeError\u001b[0m: unsupported operand type(s) for +=: 'int' and 'list'"
      ]
     }
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -261,7 +261,7 @@
        "45"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -322,10 +322,10 @@
     {
      "data": {
       "text/plain": [
-       "81"
+       "45"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -345,7 +345,7 @@
     "            #Notice we're digging in a layer here by iterating \n",
     "            #through i which we know is a nested data structure from our conditional\n",
     "    if deeper_data != []:\n",
-    "        return tot + mysum(deeper_data, tot=tot)\n",
+    "        return mysum(deeper_data, tot=tot)\n",
     "        #If we have deeper_data we got to iterate!\n",
     "    else:\n",
     "        return tot\n",
@@ -391,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Function to calculate the sum for the breadth first traversal is incorrect.  Example given is 1+2+3+4+5+6+7+8+9 and the function says it should add up to 81.  Correct answer is: 1+2+3+4+5+6+7+8+9 = 45

I updated the function - small issue where it added a variable twice.  I updated so it only added the `tot` variable once
![screen shot 2018-11-25 at 6 15 15 pm](https://user-images.githubusercontent.com/22510132/48986905-ca777600-f0df-11e8-9ceb-90b83451f59d.png)
